### PR TITLE
fix: strange hexagon rendering on firefox

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,14 +9,6 @@ module.exports = withBundleAnalyzer({
   webpack(config, meta) {
     const { buildId, dev, isServer, defaultLoaders, webpack } = meta;
 
-    config.module.rules.push({
-      test: /\.svg$/,
-      issuer: {
-        test: /\.(js|ts)x?$/,
-      },
-      loader: 'svg-sprite-loader',
-    });
-
     if (PRODUCTION_PROFILING && !dev) {
       const alias = config.resolve.alias;
       alias['react-dom$'] = 'react-dom/profiling';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
     "prettier": "^1.19.1",
-    "svg-sprite-loader": "^4.2.5",
     "typescript": "^3.8.3"
   },
   "husky": {

--- a/src/components/HexGrid.tsx
+++ b/src/components/HexGrid.tsx
@@ -2,13 +2,10 @@ import React from 'react';
 import clsx from 'clsx';
 import { makeStyles } from '@material-ui/core';
 
-import '../images/shapes.svg';
-
 export const hexagonHeight = Math.sqrt(3);
 export const hexagonAspectRatio = hexagonHeight / 2;
 
-const hexagonPoints =
-  '-0.5,0 -0.25,0.433 0.25,0.433 0.5,0 0.25,-0.433 -0.25,-0.433 -0.5,0';
+const hexagonClipUrl = 'url(#hexagonClip)';
 
 export type HexagonProps = {
   clipped?: boolean;
@@ -18,8 +15,8 @@ export const Hexagon: React.FC<HexagonProps> = props => {
   const { clipped, ...rest } = props;
   return (
     <use
-      href="#shapes_hexagon"
-      clipPath={clipped ? 'url(#shapes_hexagonClip)' : undefined}
+      href="#hexagon"
+      clipPath={clipped ? hexagonClipUrl : undefined}
       {...rest}
     />
   );
@@ -31,6 +28,12 @@ const useGridStyles = makeStyles({
     width: '100%',
     position: 'relative',
   },
+  defs: {
+    position: 'absolute',
+    height: 0,
+    width: 0,
+    // display: 'none',
+  },
   layerSvg: {
     display: 'block',
     position: 'absolute',
@@ -40,7 +43,6 @@ const useGridStyles = makeStyles({
     // right: 0,
     height: '100%',
     width: '100%',
-    pointerEvents: 'none',
     willChange: 'opacity',
   },
   spacerSvg: {
@@ -83,7 +85,7 @@ export const SVGGrid: React.FC<SVGGridProps> = props => {
       const x = xstride * (col + 0.5);
       const y = ystride * (row + 0.5);
       const el = (
-        <g key={`${row}-${col}`} transform={`translate(${x} ${y})`}>
+        <g key={`${row}-${col}`} transform={`translate(${x}, ${y})`}>
           {layers[layer]}
         </g>
       );
@@ -109,12 +111,18 @@ export const SVGGrid: React.FC<SVGGridProps> = props => {
 
   return (
     <div className={classes.wrapper}>
-      {/* <svg
-        className={classes.spacerSvg}
-        preserveAspectRatio="xMidYMid meet"
-        viewBox={viewBox}
-        {...rest}
-      ></svg> */}
+      <svg className={classes.defs} viewBox="-0.5 -0.5 1 1">
+        <defs>
+          <polygon
+            id="hexagon"
+            points="-0.5,0 -0.25,0.433 0.25,0.433 0.5,0 0.25,-0.433 -0.25,-0.433 -0.5,0"
+            vectorEffect="non-scaling-stroke"
+          />
+          <clipPath id="hexagonClip" clipPathUnits="userSpaceOnUse">
+            <polygon points="-0.5 0, -0.25 0.433, 0.25 0.433, 0.5 0, 0.25 -0.433, -0.25 -0.433, -0.5 0" />
+          </clipPath>
+        </defs>
+      </svg>
       {svgLayers}
     </div>
   );

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -32,7 +32,7 @@ function standardTransition(delayTime = 0, transitionTime = 0.5): string {
   const transition = transitionTime * transitionFactor;
   const delay = delayTime * delayFactor;
   return [
-    `transform ${transition}s ease-out ${delay}s`,
+    // `transform ${transition}s ease-out ${delay}s`,
     `opacity ${transition}s ease-out ${delay}s`,
   ].join(', ');
 }
@@ -40,6 +40,7 @@ function standardTransition(delayTime = 0, transitionTime = 0.5): string {
 const useKeyStyles = makeStyles({
   wrapper: {},
   selectable: {
+    cursor: 'pointer',
     '& $border': {
       opacity: 0.35,
     },
@@ -74,6 +75,7 @@ const useKeyStyles = makeStyles({
   notInKey: {},
   root: {
     transition: standardTransition(0),
+    userSelect: 'none',
     '& $border': {
       opacity: 0.35,
     },
@@ -126,14 +128,8 @@ const useKeyStyles = makeStyles({
   },
   content: {
     opacity: 0,
-    transition: 'inherit',
-    cursor: 'pointer',
     userSelect: 'none',
-    '$selectable &': {
-      pointerEvents: 'visibleFill',
-    },
-  },
-  label: {
+    transition: 'inherit',
     fontSize: '0.33px', // svg pixels
     textAnchor: 'middle',
     letterSpacing: 'normal',
@@ -167,6 +163,7 @@ const NoteKey: React.FC<NoteKeyProps> = props => {
 
   return (
     <g
+      onMouseDown={onClick}
       className={clsx(colorClass, classes.wrapper, classes[role], {
         [classes.expanded]: showAs === 'expanded',
         [classes.collapsed]: showAs === 'collapsed',
@@ -183,16 +180,9 @@ const NoteKey: React.FC<NoteKeyProps> = props => {
       <Hexagon clipped className={classes.border} />
       <Hexagon className={classes.edge} />
 
-      <g
-        onMouseDown={onClick}
-        clipPath="url(shapes_hexagonClip)"
-        className={classes.content}
-      >
-        <circle cx={0} cy={0} r={0.5} fill="none" />
-        <text x="0" y="0.125" className={classes.label}>
-          {label}
-        </text>
-      </g>
+      <text x="0" y="0.125" className={classes.content}>
+        {label}
+      </text>
     </g>
   );
 };

--- a/src/images/shapes.svg
+++ b/src/images/shapes.svg
@@ -5,9 +5,9 @@
     <!-- <polygon id="hexagon" transform="scale(1, 0.866)" points="-0.5,0 -0.25,0.5 0.25,0.5 0.5,0 0.25,-0.5 -0.25,-0.5 -0.5,0" vector-effect="non-scaling-stroke"/> -->
     <polygon id="hexagon" points="-0.5,0 -0.25,0.433 0.25,0.433 0.5,0 0.25,-0.433 -0.25,-0.433 -0.5,0" vector-effect="non-scaling-stroke"/>
     <circle id="circle" cx="0" cy="0" r="0.5" vector-effect="non-scaling-stroke"/>
-    <clipPath id="hexagonClip" clip-path-units="objectBoundingBox">
-      <!-- <use href="hexagon" /> -->
-      <polygon points="-0.5,0 -0.25,0.433 0.25,0.433 0.5,0 0.25,-0.433 -0.25,-0.433 -0.5,0"/>
+    <clipPath id="hexagonClip" clip-path-units="userSpaceOnUse">
+      <!-- <use href="hexagon" transform="scaleY(1.1547) translate(0.5 0.5)" /> -->
+      <polygon points="-0.5 0, -0.25 0.433, 0.25 0.433, 0.5 0, 0.25 -0.433, -0.25 -0.433, -0.5 0"/>
     </clipPath>
     <clipPath id="circleClip">
       <!-- <use href="circle" /> -->


### PR DESCRIPTION
The culprit was the <symbol> wrapper inserted by svg-sprite-loader,
which for some reason FF (but not Chrome) refused to use the clipPath
inside. We now just drop the SVG <defs> into the HexGrid itself.